### PR TITLE
Remove Extra Item Skip for SHAR Parse

### DIFF
--- a/lastpass/parser.py
+++ b/lastpass/parser.py
@@ -98,8 +98,6 @@ def parse_SHAR(chunk, encryption_key, rsa_key):
     id = read_item(io)
     encrypted_key = decode_hex(read_item(io))
     encrypted_name = read_item(io)
-    for _ in range(2):
-        skip_item(io)
     skip_item(io, 2)
     key = read_item(io)
 


### PR DESCRIPTION
skip_item(io) was being called twice which caused downstream issues trying to unpack the wrong string in read_uint32()
Fixes issue with error: unpack requires a string argument of length 4

NOTE: I don't know that the new key works towards decrypting shared accounts, but this will stop error from blocking object initialization