### PR TITLE
Fix Bug in SHAR

### DIFF
--- a/lastpass/parser.py
+++ b/lastpass/parser.py
@@ -98,8 +98,6 @@ def parse_SHAR(chunk, encryption_key, rsa_key):
     id = read_item(io)
     encrypted_key = decode_hex(read_item(io))
     encrypted_name = read_item(io)
-    for _ in range(2):
-        skip_item(io)
     skip_item(io, 2)
     key = read_item(io)
 


### PR DESCRIPTION
skip_item was being doubled up because it was done in different ways
removed doubling up and now the code runs smoothly
(checked logic in Ruby package github logic)