### PR TITLE
Ignore PEP8 "E731 do not assign a lambda expression, use a def".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - "pip install coveralls"
   - "if [[ $TEST_PEP8 == '1' ]]; then pip install pep8; fi"
 script:
-  - "if [[ $TEST_PEP8 == '1' ]]; then pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,lastpass_python.egg-info,.git --ignore=E501 .; else nosetests --with-coverage --cover-package=lastpass; fi"
+  - "if [[ $TEST_PEP8 == '1' ]]; then pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,lastpass_python.egg-info,.git --ignore=E501,E731 .; else nosetests --with-coverage --cover-package=lastpass; fi"
 after_success:
   - "if [[ $TEST_PEP8 == '1' ]]; then echo 'No coverage report when running pep8' ; else coveralls ; fi"
 matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands = pip install -r requirements.txt
 
 [testenv:pep8]
 deps = pep8
-commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg,.git --ignore=E501 .
+commands = pep8 --repeat --show-source --exclude=.venv,.tox,dist,docs,build,*.egg,.git --ignore=E501,E731 .


### PR DESCRIPTION
Code like:
```
(lastpass/fetcher.py:131:9)

prf = lambda p, s: HMAC.new(p, s, SHA256).digest()
return PBKDF2(password.encode(), username.encode(), 32, key_iteration_count, prf)
```
triggers PEP8 E731 "do not assign a lambda expression, use a def" because the lambda is assigned to the variable `prf` before being used.

Ignore the error to fix the build since it looks better splitted.