### PR TITLE
Compat with python 27 for fetcher

### DIFF
--- a/lastpass/fetcher.py
+++ b/lastpass/fetcher.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import hashlib
+from builtins import bytes
 from base64 import b64decode
 from binascii import hexlify
 from Crypto.Hash import HMAC, SHA256
@@ -118,20 +119,20 @@ def decode_blob(blob):
 
 def make_key(username, password, key_iteration_count):
     if key_iteration_count == 1:
-        return hashlib.sha256(username.encode() + password.encode()).digest()
+        return hashlib.sha256(bytes(username, 'utf-8') + bytes(password, 'utf-8')).digest()
     else:
         prf = lambda p, s: HMAC.new(p, s, SHA256).digest()
-        return PBKDF2(password.encode(), username.encode(), 32, key_iteration_count, prf)
+        return PBKDF2(password, username, 32, key_iteration_count, prf)
 
 
 def make_hash(username, password, key_iteration_count):
     if key_iteration_count == 1:
-        return bytearray(hashlib.sha256(hexlify(make_key(username, password, 1)) + password.encode()).hexdigest(), 'ascii')
+        return bytearray(hashlib.sha256(hexlify(make_key(username, password, 1)) + bytes(password, 'utf-8')).hexdigest(), 'ascii')
     else:
         prf = lambda p, s: HMAC.new(p, s, SHA256).digest()
         return hexlify(PBKDF2(
             make_key(username, password, key_iteration_count),
-            password.encode(),
+            bytes(password, 'utf-8'),
             32,
             1,
             prf))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mock==1.0.1
 tox==1.7.2
 nose==1.3.4
 coverage==3.7.1
+future==0.16.0


### PR DESCRIPTION
Avoid errors like UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 9: ordinal not in range(128)

As this would only work on python3 and raise an UnicodeDecodeError in python2.7
``` python
'pâsswôrd'.encode()
```

I could only connect once I replaced those conversions

About PBKDF2 it seems it does already calls `tobytes` function for compatibility. (to be confirmed)


