### PR TITLE
handle 'notes' field on Accounts

### DIFF
--- a/lastpass/account.py
+++ b/lastpass/account.py
@@ -1,9 +1,10 @@
 # coding: utf-8
 class Account(object):
-    def __init__(self, id, name, username, password, url, group):
+    def __init__(self, id, name, username, password, url, group, notes=None):
         self.id = id
         self.name = name
         self.username = username
         self.password = password
         self.url = url
         self.group = group
+        self.notes = notes

--- a/lastpass/parser.py
+++ b/lastpass/parser.py
@@ -61,6 +61,8 @@ def parse_ACCT(chunk, encryption_key):
     skip_item(io, 2)
     secure_note = read_item(io)
 
+    if len(notes) == 0:
+        notes = None
     # Parse secure note
     if secure_note == b"1":
         skip_item(io, 17)
@@ -72,7 +74,7 @@ def parse_ACCT(chunk, encryption_key):
 
         url, username, password = parse_secure_note_server(notes)
 
-    return Account(id, name, username, password, url, group)
+    return Account(id, name, username, password, url, group, notes=notes)
 
 
 def parse_PRIK(chunk, encryption_key):


### PR DESCRIPTION
This handles the free-form text "notes" field on Accounts, that for some reason was being silently thrown away...