### PR TITLE
Set `User-Agent` to `lastpass-python/x.x.x`

### DIFF
--- a/lastpass/__init__.py
+++ b/lastpass/__init__.py
@@ -1,7 +1,3 @@
 from .vault import Vault
 from .exceptions import *
-
-__version__ = '0.3.1'
-
-# lastpass-ruby's version
-VERSION = '1.5.0'
+from .version import *

--- a/lastpass/fetcher.py
+++ b/lastpass/fetcher.py
@@ -5,6 +5,7 @@ from binascii import hexlify
 import requests
 from xml.etree import ElementTree as etree
 from . import blob
+from .version import __version__
 from .exceptions import (
     NetworkError,
     InvalidResponseError,
@@ -19,8 +20,7 @@ from .session import Session
 
 
 http = requests
-
-headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36'}
+headers = {'user-agent': 'lastpass-python/{}'.format(__version__)}
 
 
 def login(username, password, multifactor_password=None, client_id=None):

--- a/lastpass/fetcher.py
+++ b/lastpass/fetcher.py
@@ -22,6 +22,7 @@ http = requests
 
 headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36'}
 
+
 def login(username, password, multifactor_password=None, client_id=None):
     key_iteration_count = request_iteration_count(username)
     return request_login(username, password, key_iteration_count, multifactor_password, client_id)

--- a/lastpass/version.py
+++ b/lastpass/version.py
@@ -1,0 +1,4 @@
+__version__ = '0.3.1'
+
+# lastpass-ruby's version
+VERSION = '1.5.0'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 def get_version():
     import re
-    with open('lastpass/__init__.py', 'r') as f:
+    with open('lastpass/version.py', 'r') as f:
         for line in f:
             m = re.match(r'__version__ = [\'"]([^\'"]*)[\'"]', line)
             if m:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -60,7 +60,9 @@ class FetcherTestCase(unittest.TestCase):
         m = mock.Mock()
         m.post.return_value = self._http_ok(str(self.key_iteration_count))
         fetcher.request_iteration_count(self.username, m)
-        m.post.assert_called_with('https://lastpass.com/iterations.php', data={'email': self.username})
+        m.post.assert_called_with('https://lastpass.com/iterations.php',
+                                  data={'email': self.username},
+                                  headers=fetcher.headers)
 
     def test_request_iteration_count_returns_key_iteration_count(self):
         m = mock.Mock()
@@ -201,7 +203,9 @@ class FetcherTestCase(unittest.TestCase):
         m = mock.Mock()
         m.post.return_value = self._http_ok('<ok sessionid="{}" />'.format(self.session_id))
         fetcher.request_login(self.username, self.password, self.key_iteration_count, multifactor_password, device_id, m)
-        m.post.assert_called_with('https://lastpass.com/login.php', data=post_data)
+        m.post.assert_called_with('https://lastpass.com/login.php',
+                                  data=post_data,
+                                  headers=fetcher.headers)
 
     @staticmethod
     def _mock_response(code, body):


### PR DESCRIPTION
- Set user-agent to `lastpass-python/x.x.x`
- Fix failing tests

Related: https://github.com/konomae/lastpass-python/pull/41