### PR TITLE
Change `request_iteration_count` to use a GET request

### DIFF
--- a/lastpass/fetcher.py
+++ b/lastpass/fetcher.py
@@ -50,8 +50,8 @@ def fetch(session, web_client=http):
 
 
 def request_iteration_count(username, web_client=http):
-    response = web_client.post('https://lastpass.com/iterations.php',
-                               data={'email': username},
+    response = web_client.get('https://lastpass.com/iterations.php',
+                               params={'email': username},
                                headers=headers)
     if response.status_code != requests.codes.ok:
         raise NetworkError()

--- a/lastpass/fetcher.py
+++ b/lastpass/fetcher.py
@@ -51,8 +51,8 @@ def fetch(session, web_client=http):
 
 def request_iteration_count(username, web_client=http):
     response = web_client.get('https://lastpass.com/iterations.php',
-                               params={'email': username},
-                               headers=headers)
+                              params={'email': username},
+                              headers=headers)
     if response.status_code != requests.codes.ok:
         raise NetworkError()
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -58,35 +58,35 @@ class FetcherTestCase(unittest.TestCase):
 
     def test_request_iteration_count_makes_a_post_request(self):
         m = mock.Mock()
-        m.post.return_value = self._http_ok(str(self.key_iteration_count))
+        m.get.return_value = self._http_ok(str(self.key_iteration_count))
         fetcher.request_iteration_count(self.username, m)
-        m.post.assert_called_with('https://lastpass.com/iterations.php',
-                                  data={'email': self.username},
+        m.get.assert_called_with('https://lastpass.com/iterations.php',
+                                  params={'email': self.username},
                                   headers=fetcher.headers)
 
     def test_request_iteration_count_returns_key_iteration_count(self):
         m = mock.Mock()
-        m.post.return_value = self._http_ok(str(self.key_iteration_count))
+        m.get.return_value = self._http_ok(str(self.key_iteration_count))
         self.assertEqual(fetcher.request_iteration_count(self.username, m), self.key_iteration_count)
 
     def test_request_iteration_count_raises_an_exception_on_http_error(self):
         m = mock.Mock()
-        m.post.return_value = self._http_error()
+        m.get.return_value = self._http_error()
         self.assertRaises(lastpass.NetworkError, fetcher.request_iteration_count, self.username, m)
 
     def test_request_iteration_count_raises_an_exception_on_invalid_key_iteration_count(self):
         m = mock.Mock()
-        m.post.return_value = self._http_ok('not a number')
+        m.get.return_value = self._http_ok('not a number')
         self.assertRaises(lastpass.InvalidResponseError, fetcher.request_iteration_count, self.username, m)
 
     def test_request_iteration_count_raises_an_exception_on_zero_key_iteration_cont(self):
         m = mock.Mock()
-        m.post.return_value = self._http_ok('0')
+        m.get.return_value = self._http_ok('0')
         self.assertRaises(lastpass.InvalidResponseError, fetcher.request_iteration_count, self.username, m)
 
     def test_request_iteration_count_raises_an_exception_on_negative_key_iteration_cont(self):
         m = mock.Mock()
-        m.post.return_value = self._http_ok('-1')
+        m.get.return_value = self._http_ok('-1')
         self.assertRaises(lastpass.InvalidResponseError, fetcher.request_iteration_count, self.username, m)
 
     def test_request_login_makes_a_post_request(self):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -61,8 +61,8 @@ class FetcherTestCase(unittest.TestCase):
         m.get.return_value = self._http_ok(str(self.key_iteration_count))
         fetcher.request_iteration_count(self.username, m)
         m.get.assert_called_with('https://lastpass.com/iterations.php',
-                                  params={'email': self.username},
-                                  headers=fetcher.headers)
+                                 params={'email': self.username},
+                                 headers=fetcher.headers)
 
     def test_request_iteration_count_returns_key_iteration_count(self):
         m = mock.Mock()


### PR DESCRIPTION
This is the fix suggested in https://github.com/konomae/lastpass-python/issues/44#issuecomment-847096643. It was tested with my personal account and it works well.

Whilst testing, I also found that changing the request to `/iterations.php` to a `GET` is not enough. The `User-Agent` in the header must also be changed from `python/requests` to something else. It doesn't matter what it's changed to. For this repo, this was already fixed in commit fad6e0cea014796ed96235ae85c1fa7a42c54860. 

As noted in https://github.com/lastpass/lastpass-cli/issues/604, one workaround is to change the iterations to 100100 by performing the following:

> 1. Open `Account Settings` in your browser (`Open My Vault` → `Account Settings`)
> 2. Press `Show Advanced Settings`
> 3. Set `General → Security → Password Iterations` to _exactly_ `100100`
> 
> LastPass will ask for your Master password and re-encrypt your vault.

Closes https://github.com/konomae/lastpass-python/issues/44
